### PR TITLE
adds a get timeout to prevent session errors

### DIFF
--- a/lib/connect-appbase.js
+++ b/lib/connect-appbase.js
@@ -17,15 +17,19 @@ module.exports = function(session){
 	util.inherits(AppbaseStore, Store);
 	
 	AppbaseStore.prototype.get = function(sid, fn){
-		this.client.get({
-			type: 'SessionStore',
-			id: sid
-		}).on('data', function(response) {
-			var result = response._source;
-			fn(null, result);
-		}).on('error', function(error) {
-			fn(error);
-		});
+		var self = this;
+		// a small timeout 0.5s to allow set to register before get
+		setTimeout(function() {
+			self.client.get({
+				type: 'SessionStore',
+				id: sid
+			}).on('data', function(response) {
+				var result = response._source;
+				fn(null, result);
+			}).on('error', function(error) {
+				fn(error);
+			})
+		}, 500);
 	};
 	
 	AppbaseStore.prototype.set = function(sid, sess, fn){		


### PR DESCRIPTION
- on the first token registration, `get` can occur before `set` causing an error. We prevent this scenario by adding a small timeout before executing get.
